### PR TITLE
Set websocket idle timeout to infinity

### DIFF
--- a/lib/plug_live_reload/socket.ex
+++ b/lib/plug_live_reload/socket.ex
@@ -57,7 +57,7 @@ defmodule PlugLiveReload.Socket do
 
   @impl :cowboy_websocket
   def init(request, state \\ %{}) do
-    {:cowboy_websocket, request, state}
+    {:cowboy_websocket, request, state, %{idle_timeout: :infinity}}
   end
 
   @impl :cowboy_websocket


### PR DESCRIPTION
The websocket by default closes the connection after 60 seconds of inactivity. This change will allow the websocket connection to stay open indefinitely.